### PR TITLE
Feature/docker compose

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_PATH: "vendor/bundle"

--- a/README.md
+++ b/README.md
@@ -10,12 +10,18 @@ Using Docker Compose:
 $ docker-compose up
 ```
 
+> Make sure you have [Docker Compose installed](https://docs.docker.com/compose/install/) to run it.
+
 Using your local Ruby environment:
 
 ```sh
 $ bundle install
 $ bundle exec jekyll serve
 ```
+
+---
+
+The blog is served at http://localhost:4000
 
 ## Content
 
@@ -41,7 +47,7 @@ Do you have an interesting topic to share but it's not technical? we have a plac
 * Create a file inside folder [_posts/](_posts/) with the following naming convention: `yyyy-mm-dd-title-with-spaces.md`
 * Add images that you'll use in this post to folder [assets/images/post/](assets/images/post/)
 * Ensure your header is correct. Use existing posts as an example, both for the header and the content.
-* Ensure you run `bundle install && bundle exec jekyll serve` locally and double check everything is fine at http://127.0.0.1:4000/ before submitting a PR to branch `main`.
+* Ensure you [run it locally](#build-locally) and double check everything is fine in your browser before submitting a PR to branch `main`.
 
 ## Linting your posts
 
@@ -51,7 +57,7 @@ The linting tool is [Vale](https://github.com/errata-ai/vale) and you can run it
 
 
 ```bash
-vale --glob='*.md' --minAlertLevel=warning .
+$ vale --glob='*.md' --minAlertLevel=warning .
 ```
 
 For more information, check the [usage docs](https://docs.errata.ai/vale/cli)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@ Static blog powered by [Jekyll](https://jekyllrb.com/)
 
 ## Build locally
 
+Using Docker Compose:
+
 ```sh
-bundle install
-bundle exec jekyll serve
+$ docker-compose up
+```
+
+Using your local Ruby environment:
+
+```sh
+$ bundle install
+$ bundle exec jekyll serve
 ```
 
 ## Content

--- a/_config.yml
+++ b/_config.yml
@@ -90,12 +90,11 @@ footer:
 #   - vendor/ruby/
 include:
   - _pages
-  - vendor/bundle
 
 sass:
   style: compressed
   load_paths:
-    - ./vendor/bundle/ruby/*/gems/bootstrap-5.0.0/assets/stylesheets
+    - ./assets/css/vendor/bootstrap
 
 # Defaults
 defaults:

--- a/_plugins/jekyll_asset_pipeline.rb
+++ b/_plugins/jekyll_asset_pipeline.rb
@@ -1,5 +1,6 @@
 require 'jekyll_asset_pipeline'
 require 'fileutils'
+require 'bootstrap'
 
 def copy_files(source, destination)
 	puts %(copy_files.rb: Copying files from "#{source}" to "#{destination}")
@@ -8,5 +9,6 @@ def copy_files(source, destination)
 end
 
 Jekyll::Hooks.register :site, :after_init do |jekyll|
-	copy_files 'vendor/bundle/ruby/*/gems/bootstrap-5.0.0/assets/javascripts', 'assets/js/vendor/bootstrap'
+	copy_files "#{Bootstrap.gem_path}/assets/javascripts", "assets/js/vendor/bootstrap"
+  copy_files "#{Bootstrap.gem_path}/assets/stylesheets", "assets/css/vendor/bootstrap"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+
+services:
+  jekyll:
+    image: jekyll/jekyll:latest
+    command: jekyll serve --watch --force_polling --verbose
+    ports:
+      - 4000:4000
+    volumes:
+      - .:/srv/jekyll


### PR DESCRIPTION
This PR aims to make the local setup easier for content creators.

The changes include:

1. Remove dependency of custom local vendor directory, so the copy of the asset works in a Docker container;
2. Creation of a Docker Compose file to run a container for Jekyll locally.