### PR TITLE
Allow future posts in local setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
   jekyll:
     image: jekyll/jekyll:latest
-    command: jekyll serve --watch --force_polling --verbose
+    command: jekyll serve --watch --force_polling --verbose --future
     ports:
       - 4000:4000
     volumes:


### PR DESCRIPTION
Adding `--future` to Docker command so future posts will show up in dev environment.