### PR TITLE
Update footer links to social media

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-linux)
+      racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -175,6 +177,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   universal-darwin-22
+  x86_64-linux-musl
 
 DEPENDENCIES
   bootstrap (~> 5.0.2)

--- a/_config.yml
+++ b/_config.yml
@@ -67,7 +67,7 @@ footer:
       url: https://www.linkedin.com/company/backbase/
       icon: fab fa-linkedin-in
     - label: Instagram
-      url: https://www.instagram.com/life_at_backbase/
+      url: https://www.instagram.com/backbase_global/
       icon: fab fa-instagram
     - label: Glassdoor
       url: https://www.glassdoor.nl/Overzicht/Werken-bij-Backbase-EI_IE117266.11,19.htm?countryRedirect=true
@@ -75,9 +75,6 @@ footer:
     - label: Facebook
       url: https://www.facebook.com/backbase
       icon: fab fa-facebook-f
-    - label: Stack Overflow
-      url: https://stackoverflow.com/jobs/companies/backbase
-      icon: fab fa-stack-overflow
 
 # Exclude from processing.
 # The following items will not be processed, by default.


### PR DESCRIPTION
This PR updates the link to instagram, which was recently changed, and removes link to stackoverflow, which is discontinued.