### PR TITLE
Update linting.yml

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Vale
       uses: errata-ai/vale-action@v2.0.1
       with:
-         onlyAnnotateModifiedLines: true
+         filter_mode: added
          reporter: github-pr-check
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Pull requests are being blocked even when there is no errors in the context of the request. This PR adds the filter mode `added`, which will limit the scope of the execution to the changed lines only.