### PR TITLE
fix references list bullet of jest migration post

### DIFF
--- a/content/posts/2024/05/06/migration-from-karma-jasmine-to-jest/post.md
+++ b/content/posts/2024/05/06/migration-from-karma-jasmine-to-jest/post.md
@@ -134,6 +134,6 @@ In Backbase, we use Nx Angular schematics to generate our applications. The step
 
 ## References
 
-**transformIgnorePatterns**: [Troubleshooting | jest-preset-angular](https://thymikee.github.io/jest-preset-angular/docs/guides/troubleshooting/#unexpected-token-importexportother)
+- [transformIgnorePatterns Troubleshooting | jest-preset-angular](https://thymikee.github.io/jest-preset-angular/docs/guides/troubleshooting/#unexpected-token-importexportother)
 
-[@nx/jest](https://nx.dev/nx-api/jest)
+- [@nx/jest](https://nx.dev/nx-api/jest)

--- a/routes.txt
+++ b/routes.txt
@@ -19,10 +19,10 @@
 /2023/11/21/a-new-chapter-exploring-azure-resources
 /2023/12/13/angular-micro-frontends
 /2024/05/01/liquibase-as-an-init-container
+/2024/05/06/migration-from-karma-jasmine-to-jest
+/2024/05/06/working-with-testcontainers
 /principles/innersource
 /principles/software-engineering
-/unpublished/working-with-test-containers
-/unpublished/migration-from-karma-jasmine-to-jest
 /category/tech-life
 /category/devops
 /category/backend


### PR DESCRIPTION
Fix for the references that are not being displayed in an understandable way for the jest migration post